### PR TITLE
Fix error NU5030: The license file 'LICENSE' does not exist in the package.

### DIFF
--- a/Resources/MonoGame.Library.X.txt
+++ b/Resources/MonoGame.Library.X.txt
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <None Include="{LicencePath}" Pack="true" PackagePath="{LicenceName}" />
+      <None Include="{LicencePath}" Pack="true" PackagePath="{LicencePackagePath}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tasks/PublishPackageTask.cs
+++ b/Tasks/PublishPackageTask.cs
@@ -58,14 +58,14 @@ public sealed class PublishPackageTask : AsyncFrostingTask<BuildContext>
         projectData = projectData.Replace("{LicencePath}", context.PackContext.LicensePath);
 
         if (context.PackContext.LicensePath.EndsWith(".txt"))
-            projectData = projectData.Replace("{LicenceName}", "LICENSE.txt").Replace ("{LicencePackagePath}", "LICENSE.txt");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE.txt").Replace("{LicencePackagePath}", "LICENSE.txt");
         else if (context.PackContext.LicensePath.EndsWith(".md"))
-            projectData = projectData.Replace("{LicenceName}", "LICENSE.md").Replace ("{LicencePackagePath}", "LICENSE.md");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE.md").Replace("{LicencePackagePath}", "LICENSE.md");
         else if (context.PackContext.LicensePath.EndsWith ("LICENSE"))
             // https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030#issue
-            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace ("{LicencePackagePath}", "");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace("{LicencePackagePath}", "");
         else
-            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace ("{LicencePackagePath}", "LICENSE");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace("{LicencePackagePath}", "");
 
         var librariesToInclude = from rid in requiredRids from filePath in Directory.GetFiles($"runtimes/{rid}/native")
             select $"<Content Include=\"{filePath}\"><PackagePath>runtimes/{rid}/native</PackagePath></Content>";

--- a/Tasks/PublishPackageTask.cs
+++ b/Tasks/PublishPackageTask.cs
@@ -61,10 +61,8 @@ public sealed class PublishPackageTask : AsyncFrostingTask<BuildContext>
             projectData = projectData.Replace("{LicenceName}", "LICENSE.txt").Replace("{LicencePackagePath}", "LICENSE.txt");
         else if (context.PackContext.LicensePath.EndsWith(".md"))
             projectData = projectData.Replace("{LicenceName}", "LICENSE.md").Replace("{LicencePackagePath}", "LICENSE.md");
-        else if (context.PackContext.LicensePath.EndsWith ("LICENSE"))
-            // https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030#issue
-            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace("{LicencePackagePath}", "");
         else
+            // https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030#issue
             projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace("{LicencePackagePath}", "");
 
         var librariesToInclude = from rid in requiredRids from filePath in Directory.GetFiles($"runtimes/{rid}/native")

--- a/Tasks/PublishPackageTask.cs
+++ b/Tasks/PublishPackageTask.cs
@@ -58,11 +58,14 @@ public sealed class PublishPackageTask : AsyncFrostingTask<BuildContext>
         projectData = projectData.Replace("{LicencePath}", context.PackContext.LicensePath);
 
         if (context.PackContext.LicensePath.EndsWith(".txt"))
-            projectData = projectData.Replace("{LicenceName}", "LICENSE.txt");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE.txt").Replace ("{LicencePackagePath}", "LICENSE.txt");
         else if (context.PackContext.LicensePath.EndsWith(".md"))
-            projectData = projectData.Replace("{LicenceName}", "LICENSE.md");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE.md").Replace ("{LicencePackagePath}", "LICENSE.md");
+        else if (context.PackContext.LicensePath.EndsWith ("LICENSE"))
+            // https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030#issue
+            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace ("{LicencePackagePath}", "");
         else
-            projectData = projectData.Replace("{LicenceName}", "LICENSE");
+            projectData = projectData.Replace("{LicenceName}", "LICENSE").Replace ("{LicencePackagePath}", "LICENSE");
 
         var librariesToInclude = from rid in requiredRids from filePath in Directory.GetFiles($"runtimes/{rid}/native")
             select $"<Content Include=\"{filePath}\"><PackagePath>runtimes/{rid}/native</PackagePath></Content>";


### PR DESCRIPTION
Context https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030#issue

This has come up with the Assimp repository https://github.com/MonoGame/MonoGame.Library.Assimp.
When the filename of the license file has no extension NuGet reports an error. 

```
error NU5030: The license file 'LICENSE' does not exist in the package.
```

Even though we have the `PackagePath` set. According to the error page, the `PackagePath` in these cases should be empty.

To fix this we need to split out the `LicenceName` tag into two values so that they can be set independently. So we add `LicenceNamePackagePath` tag so that we can do so. Existing code should behave the same way.