### PR TITLE
And Android Test Task

### DIFF
--- a/Tasks.cs
+++ b/Tasks.cs
@@ -8,6 +8,7 @@ public class BuildLibraryTask : FrostingTask { }
 [IsDependentOn(typeof(TestWindowsTask))]
 [IsDependentOn(typeof(TestMacOSTask))]
 [IsDependentOn(typeof(TestLinuxTask))]
+[IsDependentOn(typeof(TestAndroidTask))]
 public class TestLibraryTask : FrostingTask { }
 
 [TaskName("Default")]

--- a/Tasks/PublishLibraryTask.cs
+++ b/Tasks/PublishLibraryTask.cs
@@ -37,8 +37,10 @@ public sealed class PublishLibraryTask : AsyncFrostingTask<BuildContext>
             }
         }
 
-        foreach (var r in availableRids)
+        foreach (var r in availableRids) {
+            context.Information($"Uploading: {context.ArtifactsDir}/{r} to artifacts-{r}");
             await context.BuildSystem().GitHubActions.Commands.UploadArtifact(DirectoryPath.FromString($"{context.ArtifactsDir}/{r}"), $"artifacts-{r}");
+        }
 
         if (availableRids.Any ())
             return;
@@ -58,6 +60,7 @@ public sealed class PublishLibraryTask : AsyncFrostingTask<BuildContext>
                 _ => "-x64",
             };
         }
+        context.Information($"Uploading: {context.ArtifactsDir} to artifacts-{rid}");
         await context.BuildSystem().GitHubActions.Commands.UploadArtifact(DirectoryPath.FromString(context.ArtifactsDir), $"artifacts-{rid}");
     }
 }

--- a/Tasks/TestAndroidTask.cs
+++ b/Tasks/TestAndroidTask.cs
@@ -32,7 +32,7 @@ public sealed class TestAndroidTask : FrostingTask<BuildContext>
         string readelf = string.Empty;
         var files = Directory.GetFiles (System.IO.Path.Combine(ndk, "toolchains/llvm/prebuilt"), "llvm-readelf", SearchOption.AllDirectories);
         if (files.Length > 0) {
-            readelf = files.First (l => l == "llvm-readelf");
+            readelf = files.First (l => l.EndsWith ("llvm-readelf"));
         }
         if (string.IsNullOrEmpty (readelf)) {
             context.Information($"SKIP: could not find llvm-readelf");

--- a/Tasks/TestAndroidTask.cs
+++ b/Tasks/TestAndroidTask.cs
@@ -1,8 +1,8 @@
 
 namespace BuildScripts;
 
-[TaskName("Test Linux")]
-public sealed class TestLinuxTask : FrostingTask<BuildContext>
+[TaskName("Test Android")]
+public sealed class TestAndroidTask : FrostingTask<BuildContext>
 {
     private static readonly string[] ValidLibs = {
         "linux-vdso.so",
@@ -14,22 +14,39 @@ public sealed class TestLinuxTask : FrostingTask<BuildContext>
         "libpthread.so",
         "/lib/ld-linux-",
         "/lib64/ld-linux-",
+        "linux-gate.so.1",
+        "libOpenSLES.so",
+        "liblog.so"
     };
 
     public override bool ShouldRun(BuildContext context) => context.IsRunningOnLinux();
 
     public override void Run(BuildContext context)
     {
-        var rootFiles = Directory.GetFiles(context.ArtifactsDir);
-        var linuxFiles = Directory.GetFiles(context.ArtifactsDir, "linux-*", SearchOption.AllDirectories);
-        foreach (var filePath in rootFiles.Union (linuxFiles))
+        var ndk = System.Environment.GetEnvironmentVariable ("ANDROID_NDK_HOME");
+        if (string.IsNullOrEmpty (ndk)) {
+            context.Information($"SKIP: no ANDROID_NDK+HOME found.");
+            return;
+        }
+        ///toolchains/llvm/prebuilt/*/bin/lld
+        string readelf = string.Empty;
+        var files = Directory.GetFiles (System.IO.Path.Combine(ndk, "toolchains/llvm/prebuilt"), "llvm-readelf", SearchOption.AllDirectories);
+        if (files.Length > 0) {
+            readelf = files.First (l => l == "llvm-readelf");
+        }
+        if (string.IsNullOrEmpty (readelf)) {
+            context.Information($"SKIP: could not find llvm-readelf");
+            return;
+        }
+
+        foreach (var filePath in Directory.GetFiles(context.ArtifactsDir, "android-*", SearchOption.AllDirectories))
         {
             context.Information($"Checking: {filePath}");
             context.StartProcess(
-                "ldd",
+                readelf,
                 new ProcessSettings
                 {
-                    Arguments = $"{filePath}",
+                    Arguments = $"--needed-libs {filePath}",
                     RedirectStandardOutput = true
                 },
                 out IEnumerable<string> processOutput);
@@ -37,7 +54,9 @@ public sealed class TestLinuxTask : FrostingTask<BuildContext>
             var passedTests = true;
             foreach (var line in processOutput)
             {
-                var libPath = line.Trim().Split(' ')[0];
+                if (line.Contains('[') || line.Contains(']'))
+                    continue;
+                var libPath = line.Trim();
 
                 var isValidLib = false;
                 foreach (var validLib in ValidLibs)

--- a/Tasks/TestMacOSTask.cs
+++ b/Tasks/TestMacOSTask.cs
@@ -81,7 +81,7 @@ public sealed class TestMacOSTask : FrostingTask<BuildContext>
                 context.Information($"ARCHITECTURE: arm64");
             }
 
-            if (context.IsUniversalBinary && !(arm64 && x86_64))
+            if (context.IsUniversalBinary && filePath.Contains ("osx") && !(arm64 && x86_64))
             {
                 context.Information($"INVALID universal binary");
                 throw new Exception("An universal binary hasn't been generated!");


### PR DESCRIPTION
Split out the tests for Android into their own Task so we can use the NDK llvm-readelf to check the files.

Only check for universal binaries if the we are processing a osx dylib. iOS device/simulator dylibs are currently not build as universal binaries.