### PR TITLE
Bumped Cake Nugets to 5.x and 7.x respectively and that required the …

### DIFF
--- a/MonoGame.Library.BuildScripts.csproj
+++ b/MonoGame.Library.BuildScripts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -37,9 +37,9 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
-    <PackageReference Include="Cake.Frosting" Version="4.0.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="Cake.Frosting" Version="5.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.12.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
… .NET version to be 8. Bumped Cake versions due to vulnerabilities in the the 3.x version of Cake.

Once merged the following repos and their submodules need to be bumped too.

- [ ] MonoGame.Library.FreeImage 
- [ ] MonoGame.Library.FreeType
- [ ] MonoGame.Library.Assimp
- [ ] Others?