### PR TITLE
Add win-arm64 support for packages.

### DIFF
--- a/Tasks/PublishPackageTask.cs
+++ b/Tasks/PublishPackageTask.cs
@@ -47,6 +47,7 @@ public sealed class PublishPackageTask : AsyncFrostingTask<BuildContext>
                 "android-x64",
                 "linux-arm",
                 "linux-arm64",
+                "win-arm64",
         };
 
         // Download built artifacts


### PR DESCRIPTION
This change adds support for the 'win-arm64' runtime identifier (rid) for our packages, enabling us to build and publish NuGet packages that target Windows on ARM64 architecture.
